### PR TITLE
feat: force batch callback belt

### DIFF
--- a/lib/sidekiq/belt/pro/failed_batch_remove.rb
+++ b/lib/sidekiq/belt/pro/failed_batch_remove.rb
@@ -21,7 +21,7 @@ module Sidekiq
 
               content.gsub!(
                 "</td>\n        </tr>\n      <% end %>",
-                "</td>\n<td>#{REMOVE_BUTTON}</td>\n      </tr>\n    <% end %>"
+                "</td>\n<td>#{REMOVE_BUTTON}</td>\n        </tr>\n      <% end %>"
               )
             end
 

--- a/lib/sidekiq/belt/pro/files.rb
+++ b/lib/sidekiq/belt/pro/files.rb
@@ -3,6 +3,7 @@
 require "sidekiq"
 
 require_relative "failed_batch_remove"
+require_relative 'force_batch_callback'
 
 module Sidekiq
   module Belt
@@ -14,6 +15,7 @@ module Sidekiq
           all = options.include?(:all)
 
           Sidekiq::Belt::Pro::FailedBatchRemove.use! if all || options.include?(:failed_batch_remove)
+          Sidekiq::Belt::Pro::ForceBatchCallback.use! if all || options.include?(:force_batch_callback)
 
           true
         end

--- a/lib/sidekiq/belt/pro/force_batch_callback.rb
+++ b/lib/sidekiq/belt/pro/force_batch_callback.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "sidekiq/web/helpers"
+
+module Sidekiq
+  module Belt
+    module Pro
+      module ForceBatchCallback
+        module SidekiqForceBatchCallback
+          def self.action_button(action)
+            action_name = "force_#{action}"
+            action_chars = action.chars
+            action_button = action_chars.capitalize
+            <<~ERB
+              <form action="<%= root_path %>batches/<%= @batch.bid %>/force_callback/#{action}" method="post">
+                <%= csrf_tag %>
+                <input class="btn btn-danger" type="submit" name="#{action_name}" value="<%= t('#{action_button}') %>"
+                  data-confirm="Do you want to force the #{action} callback for batch <%= @batch.bid %>? <%= t('AreYouSure') %>" />
+              </form>
+            ERB
+          end
+
+          def self.registered(app)
+            app.replace_content("/batches/:bid") do |content|
+              content.sub!(/(<\/tbody>)/) do |match|
+                <<-HTML
+                  <tr>
+                    <th><%= t("Force Action") %></th>
+                    <td>
+                      <div style="display: flex;">
+                        #{action_button('success')}
+                        #{action_button('complete')}
+                        #{action_button('death')}
+                      </div>
+                    </td>
+                  </tr>
+                  #{match}
+                HTML
+              end
+            end
+
+            app.post("/batches/:bid/force_callback/:action") do
+              Sidekiq::Batch::Callback.perform_inline(params[:action], params[:bid])
+
+              return redirect "#{root_path}batches"
+            end
+          end
+        end
+
+        def self.use!
+          require("sidekiq/web")
+
+          Sidekiq::Web.register(Sidekiq::Belt::Pro::ForceBatchCallback::SidekiqForceBatchCallback)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates a new belt that adds the ability to execute a Batch callback on demand.

Expected use: manually force a success callback despite failures in the batch.

Example:

![image](https://github.com/user-attachments/assets/4238aac4-b659-493d-98fd-6237e7bb3819)

![image](https://github.com/user-attachments/assets/9ac385ff-489c-4cc2-9cd4-9a986227e7e1)
